### PR TITLE
Add Cambrian Explosion lifeform dex page

### DIFF
--- a/cambrian-pokedex.css
+++ b/cambrian-pokedex.css
@@ -1,0 +1,416 @@
+:root {
+  --bg-deep: #061826;
+  --bg-glow: #0f3c5d;
+  --accent-primary: #35f3ff;
+  --accent-secondary: #ff7edb;
+  --accent-tertiary: #ffe066;
+  --card-bg: rgba(8, 27, 41, 0.82);
+  --card-border: rgba(53, 243, 255, 0.5);
+  --text-main: #f3f7ff;
+  --text-muted: #c8d7ff;
+  --danger: #ff4c4c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Work Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--text-main);
+  background: radial-gradient(circle at top, rgba(53, 243, 255, 0.1), transparent 55%),
+              radial-gradient(circle at center, rgba(255, 126, 219, 0.1), transparent 60%),
+              linear-gradient(140deg, var(--bg-deep) 0%, #03101a 40%, #0b2740 100%);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: 8px;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(3, 16, 26, 0.88);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(53, 243, 255, 0.25);
+}
+
+.site-header__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.logo-cluster {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dex-label {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.1rem;
+  text-transform: uppercase;
+  color: var(--accent-tertiary);
+}
+
+.site-title {
+  margin: 0;
+  font-size: clamp(1.3rem, 2vw + 1rem, 2.2rem);
+  font-weight: 700;
+  color: var(--accent-primary);
+  text-shadow: 0 0 12px rgba(53, 243, 255, 0.4);
+}
+
+.site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-weight: 600;
+}
+
+.site-nav a {
+  color: var(--text-muted);
+  text-decoration: none;
+  padding: 6px 12px;
+  border-radius: 999px;
+  transition: background 0.2s, color 0.2s, transform 0.2s;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  background: rgba(53, 243, 255, 0.12);
+  color: var(--accent-primary);
+  transform: translateY(-2px);
+}
+
+.site-nav .nav-highlight {
+  background: linear-gradient(120deg, rgba(53, 243, 255, 0.25), rgba(255, 126, 219, 0.25));
+  color: var(--accent-secondary);
+  border: 1px solid rgba(53, 243, 255, 0.4);
+}
+
+main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.intro {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  background: rgba(6, 24, 38, 0.72);
+  border: 1px solid rgba(53, 243, 255, 0.2);
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+}
+
+.intro h2 {
+  margin-top: 0;
+  font-size: clamp(1.2rem, 1vw + 1rem, 1.8rem);
+}
+
+.intro p {
+  color: var(--text-muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.intro__metrics {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.metric {
+  background: rgba(3, 16, 26, 0.65);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid rgba(255, 126, 219, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(53, 243, 255, 0.15);
+}
+
+.metric__label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  margin-bottom: 10px;
+  color: rgba(200, 215, 255, 0.75);
+}
+
+.metric__value {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 1.2rem;
+  color: var(--accent-secondary);
+  text-shadow: 0 0 8px rgba(255, 126, 219, 0.5);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  align-items: flex-end;
+  background: rgba(3, 16, 26, 0.68);
+  border: 1px solid rgba(53, 243, 255, 0.2);
+  border-radius: 18px;
+  padding: 20px 24px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  min-width: 180px;
+  flex: 1 1 200px;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  color: rgba(200, 215, 255, 0.8);
+}
+
+.control-group input,
+.control-group select {
+  padding: 10px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(53, 243, 255, 0.35);
+  background: rgba(7, 26, 41, 0.8);
+  color: var(--text-main);
+  font-size: 0.95rem;
+  transition: border 0.2s, box-shadow 0.2s;
+}
+
+.control-group input:focus,
+.control-group select:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px rgba(53, 243, 255, 0.25);
+}
+
+.control-reset {
+  padding: 12px 24px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(120deg, rgba(53, 243, 255, 0.4), rgba(255, 126, 219, 0.4));
+  color: var(--bg-deep);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.control-reset:hover,
+.control-reset:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(53, 243, 255, 0.35);
+}
+
+.pokedex {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.pokedex-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.dex-card {
+  position: relative;
+  padding: 20px;
+  border-radius: 20px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.dex-card::before {
+  content: "";
+  position: absolute;
+  inset: -40% 50% 40% -40%;
+  background: radial-gradient(circle at top, rgba(53, 243, 255, 0.25), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.dex-card:hover,
+.dex-card:focus-within {
+  transform: translateY(-8px);
+  box-shadow: 0 26px 48px rgba(0, 0, 0, 0.35);
+}
+
+.dex-card:hover::before,
+.dex-card:focus-within::before {
+  opacity: 1;
+}
+
+.dex-card__header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 16px;
+  align-items: baseline;
+  margin-bottom: 16px;
+}
+
+.dex-number {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.7rem;
+  color: var(--accent-tertiary);
+  letter-spacing: 0.1rem;
+}
+
+.dex-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--accent-primary);
+}
+
+.dex-role {
+  grid-column: span 2;
+  font-size: 0.85rem;
+  color: rgba(255, 126, 219, 0.8);
+}
+
+.dex-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.dex-portrait {
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 126, 219, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(53, 243, 255, 0.2);
+}
+
+.dex-description {
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.dex-stats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 14px;
+}
+
+.dex-stats li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  padding: 6px 10px;
+  background: rgba(3, 16, 26, 0.6);
+  border-radius: 10px;
+  border: 1px solid rgba(53, 243, 255, 0.15);
+}
+
+.dex-ability {
+  font-size: 0.95rem;
+  background: rgba(53, 243, 255, 0.08);
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(53, 243, 255, 0.2);
+}
+
+.dex-ability strong {
+  color: var(--accent-secondary);
+}
+
+.dex-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.dex-tags li {
+  font-size: 0.75rem;
+  letter-spacing: 0.05rem;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(3, 16, 26, 0.75);
+  border: 1px solid rgba(53, 243, 255, 0.25);
+}
+
+.empty-state {
+  text-align: center;
+  font-size: 1rem;
+  color: rgba(200, 215, 255, 0.7);
+  padding: 20px;
+  background: rgba(3, 16, 26, 0.65);
+  border-radius: 16px;
+  border: 1px dashed rgba(53, 243, 255, 0.35);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 40px 24px 60px;
+  color: rgba(200, 215, 255, 0.6);
+  font-size: 0.85rem;
+}
+
+.site-footer p {
+  margin: 6px 0;
+}
+
+@media (max-width: 900px) {
+  .intro {
+    grid-template-columns: 1fr;
+  }
+
+  .intro__metrics {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .site-header__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .control-group {
+    width: 100%;
+  }
+
+  .control-reset {
+    width: 100%;
+  }
+}

--- a/cambrian-pokedex.css
+++ b/cambrian-pokedex.css
@@ -289,18 +289,33 @@ main {
 }
 
 .dex-card__header {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 6px 16px;
-  align-items: baseline;
-  margin-bottom: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 16px;
+  margin-bottom: 16px;
+}
+
+.dex-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1 1 200px;
+  min-width: 0;
+}
+
+.dex-heading-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .dex-number {
   font-family: 'Playfair Display', serif;
   font-size: 0.9rem;
   color: var(--accent-gold);
-  letter-spacing: 0.06rem;
+  letter-spacing: 0.08rem;
 }
 
 .dex-card h2 {
@@ -311,11 +326,37 @@ main {
 }
 
 .dex-role {
-  grid-column: span 2;
-  font-size: 0.8rem;
-  letter-spacing: 0.12rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  font-size: 0.7rem;
+  letter-spacing: 0.14rem;
   text-transform: uppercase;
   color: var(--accent-clay);
+  background: rgba(181, 106, 45, 0.16);
+  border: 1px solid rgba(181, 106, 45, 0.18);
+  padding: 4px 12px;
+  border-radius: 999px;
+  text-align: center;
+}
+
+.dex-avatar {
+  flex: 0 0 auto;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  margin-left: auto;
+  background: radial-gradient(120% 120% at 30% 30%, rgba(200, 154, 59, 0.4), rgba(79, 122, 85, 0.28));
+  border: 1px solid rgba(181, 106, 45, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+}
+
+.dex-avatar svg {
+  width: 44px;
+  height: 44px;
 }
 
 .dex-card__body {
@@ -415,6 +456,33 @@ main {
 
 .site-footer p {
   margin: 6px 0;
+}
+
+@media (max-width: 580px) {
+  .dex-avatar {
+    width: 56px;
+    height: 56px;
+  }
+
+  .dex-avatar svg {
+    width: 36px;
+    height: 36px;
+  }
+}
+
+@media (max-width: 480px) {
+  .dex-card__header {
+    gap: 10px;
+  }
+
+  .dex-heading-top {
+    gap: 6px;
+  }
+
+  .dex-avatar {
+    width: 52px;
+    height: 52px;
+  }
 }
 
 @media (max-width: 960px) {

--- a/cambrian-pokedex.css
+++ b/cambrian-pokedex.css
@@ -1,14 +1,19 @@
 :root {
-  --bg-deep: #061826;
-  --bg-glow: #0f3c5d;
-  --accent-primary: #35f3ff;
-  --accent-secondary: #ff7edb;
-  --accent-tertiary: #ffe066;
-  --card-bg: rgba(8, 27, 41, 0.82);
-  --card-border: rgba(53, 243, 255, 0.5);
-  --text-main: #f3f7ff;
-  --text-muted: #c8d7ff;
-  --danger: #ff4c4c;
+  --bg-sky: #f6f0e1;
+  --bg-sand: #edd7b0;
+  --bg-fern: #d5ccb2;
+  --accent-clay: #b56a2d;
+  --accent-fern: #4f7a55;
+  --accent-gold: #c89a3b;
+  --text-main: #3c3324;
+  --text-muted: #6b5a3b;
+  --card-bg: rgba(255, 250, 241, 0.92);
+  --card-border: rgba(181, 106, 45, 0.18);
+  --control-bg: rgba(255, 251, 242, 0.9);
+  --control-border: rgba(84, 68, 41, 0.18);
+  --badge-bg: rgba(79, 122, 85, 0.14);
+  --shadow-soft: 0 18px 40px rgba(60, 44, 19, 0.14);
+  --shadow-hover: 0 24px 52px rgba(60, 44, 19, 0.22);
 }
 
 * {
@@ -18,250 +23,258 @@
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: 'Work Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: 'Source Sans 3', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: var(--text-main);
-  background: radial-gradient(circle at top, rgba(53, 243, 255, 0.1), transparent 55%),
-              radial-gradient(circle at center, rgba(255, 126, 219, 0.1), transparent 60%),
-              linear-gradient(140deg, var(--bg-deep) 0%, #03101a 40%, #0b2740 100%);
+  background:
+    radial-gradient(140% 60% at 15% 10%, rgba(79, 122, 85, 0.12), transparent 60%),
+    radial-gradient(120% 75% at 80% 0%, rgba(200, 154, 59, 0.18), transparent 65%),
+    linear-gradient(180deg, var(--bg-sky) 0%, var(--bg-fern) 45%, var(--bg-sand) 100%);
+  background-attachment: fixed;
+  line-height: 1.6;
 }
 
 img {
   max-width: 100%;
   display: block;
-  border-radius: 8px;
+  border-radius: 14px;
 }
 
 .site-header {
   position: sticky;
   top: 0;
   z-index: 10;
-  background: rgba(3, 16, 26, 0.88);
-  backdrop-filter: blur(14px);
-  border-bottom: 1px solid rgba(53, 243, 255, 0.25);
+  background: rgba(250, 242, 223, 0.95);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--control-border);
+  box-shadow: 0 6px 18px rgba(60, 44, 19, 0.08);
 }
 
 .site-header__inner {
-  max-width: 1200px;
+  width: min(1100px, 100%);
   margin: 0 auto;
-  padding: 16px 24px;
+  padding: clamp(1rem, 3vw, 1.5rem) clamp(1.25rem, 4vw, 2rem);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
+  gap: clamp(1rem, 4vw, 2rem);
 }
 
 .logo-cluster {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.4rem;
 }
 
 .dex-label {
-  font-family: 'Press Start 2P', monospace;
-  font-size: 0.65rem;
-  letter-spacing: 0.1rem;
+  font-family: 'Playfair Display', serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.14rem;
   text-transform: uppercase;
-  color: var(--accent-tertiary);
+  color: var(--accent-fern);
 }
 
 .site-title {
   margin: 0;
-  font-size: clamp(1.3rem, 2vw + 1rem, 2.2rem);
-  font-weight: 700;
-  color: var(--accent-primary);
-  text-shadow: 0 0 12px rgba(53, 243, 255, 0.4);
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(1.6rem, 2vw + 1.3rem, 2.8rem);
+  font-weight: 600;
+  color: var(--accent-clay);
 }
 
 .site-nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 12px;
   font-weight: 600;
+  font-size: 0.95rem;
 }
 
 .site-nav a {
   color: var(--text-muted);
   text-decoration: none;
-  padding: 6px 12px;
+  padding: 8px 14px;
   border-radius: 999px;
-  transition: background 0.2s, color 0.2s, transform 0.2s;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .site-nav a:hover,
 .site-nav a:focus {
-  background: rgba(53, 243, 255, 0.12);
-  color: var(--accent-primary);
-  transform: translateY(-2px);
+  color: var(--accent-clay);
+  background: rgba(200, 154, 59, 0.12);
+  border-color: rgba(181, 106, 45, 0.25);
 }
 
 .site-nav .nav-highlight {
-  background: linear-gradient(120deg, rgba(53, 243, 255, 0.25), rgba(255, 126, 219, 0.25));
-  color: var(--accent-secondary);
-  border: 1px solid rgba(53, 243, 255, 0.4);
+  background: rgba(79, 122, 85, 0.18);
+  border-color: rgba(79, 122, 85, 0.2);
+  color: var(--accent-fern);
 }
 
 main {
-  max-width: 1200px;
+  width: min(1100px, 100%);
   margin: 0 auto;
-  padding: 32px 24px 80px;
+  padding: clamp(2rem, 4vw, 3rem) clamp(1.25rem, 5vw, 2.5rem) clamp(4rem, 6vw, 5rem);
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: clamp(2rem, 4vw, 3rem);
 }
 
 .intro {
   display: grid;
-  gap: 24px;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
   grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  background: rgba(6, 24, 38, 0.72);
-  border: 1px solid rgba(53, 243, 255, 0.2);
-  border-radius: 20px;
-  padding: 28px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  background: var(--control-bg);
+  border: 1px solid var(--control-border);
+  border-radius: 24px;
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  box-shadow: var(--shadow-soft);
 }
 
 .intro h2 {
   margin-top: 0;
-  font-size: clamp(1.2rem, 1vw + 1rem, 1.8rem);
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(1.4rem, 1.6vw + 1rem, 2rem);
+  color: var(--accent-clay);
 }
 
 .intro p {
   color: var(--text-muted);
-  font-size: 1rem;
-  line-height: 1.6;
+  font-size: 1.05rem;
+  line-height: 1.7;
 }
 
 .intro__metrics {
   display: grid;
-  gap: 16px;
+  gap: 18px;
   align-content: start;
 }
 
 .metric {
-  background: rgba(3, 16, 26, 0.65);
-  border-radius: 16px;
-  padding: 16px;
-  border: 1px solid rgba(255, 126, 219, 0.25);
-  box-shadow: inset 0 0 0 1px rgba(53, 243, 255, 0.15);
+  background: linear-gradient(135deg, rgba(200, 154, 59, 0.18), rgba(255, 255, 255, 0.85));
+  border-radius: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(181, 106, 45, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
 }
 
 .metric__label {
   display: block;
-  font-size: 0.75rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08rem;
-  margin-bottom: 10px;
-  color: rgba(200, 215, 255, 0.75);
+  margin-bottom: 8px;
+  color: rgba(107, 90, 59, 0.75);
 }
 
 .metric__value {
-  font-family: 'Press Start 2P', monospace;
-  font-size: 1.2rem;
-  color: var(--accent-secondary);
-  text-shadow: 0 0 8px rgba(255, 126, 219, 0.5);
+  font-family: 'Playfair Display', serif;
+  font-size: 1.5rem;
+  color: var(--accent-fern);
 }
 
 .controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 20px;
+  gap: clamp(1rem, 3vw, 1.5rem);
   align-items: flex-end;
-  background: rgba(3, 16, 26, 0.68);
-  border: 1px solid rgba(53, 243, 255, 0.2);
-  border-radius: 18px;
-  padding: 20px 24px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+  background: var(--control-bg);
+  border: 1px solid var(--control-border);
+  border-radius: 20px;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  box-shadow: var(--shadow-soft);
 }
 
 .control-group {
   display: flex;
   flex-direction: column;
-  min-width: 180px;
-  flex: 1 1 200px;
   gap: 8px;
+  flex: 1 1 220px;
+  min-width: 160px;
 }
 
 .control-group label {
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.08rem;
-  color: rgba(200, 215, 255, 0.8);
+  color: rgba(107, 90, 59, 0.8);
 }
 
 .control-group input,
 .control-group select {
-  padding: 10px 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(53, 243, 255, 0.35);
-  background: rgba(7, 26, 41, 0.8);
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(84, 68, 41, 0.25);
+  background: rgba(255, 255, 255, 0.9);
   color: var(--text-main);
-  font-size: 0.95rem;
-  transition: border 0.2s, box-shadow 0.2s;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .control-group input:focus,
 .control-group select:focus {
   outline: none;
-  border-color: var(--accent-primary);
-  box-shadow: 0 0 0 3px rgba(53, 243, 255, 0.25);
+  border-color: var(--accent-fern);
+  box-shadow: 0 0 0 4px rgba(79, 122, 85, 0.18);
 }
 
 .control-reset {
-  padding: 12px 24px;
+  padding: 12px 22px;
   border-radius: 999px;
   border: none;
-  background: linear-gradient(120deg, rgba(53, 243, 255, 0.4), rgba(255, 126, 219, 0.4));
-  color: var(--bg-deep);
+  background: linear-gradient(135deg, var(--accent-fern), #3f6446);
+  color: #fff;
   font-weight: 700;
-  text-transform: uppercase;
   letter-spacing: 0.08rem;
+  text-transform: uppercase;
   cursor: pointer;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .control-reset:hover,
 .control-reset:focus {
   transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(53, 243, 255, 0.35);
+  box-shadow: 0 10px 24px rgba(63, 100, 70, 0.3);
 }
 
 .pokedex {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .pokedex-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 24px;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .dex-card {
   position: relative;
-  padding: 20px;
-  border-radius: 20px;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  border-radius: 22px;
   background: var(--card-bg);
   border: 1px solid var(--card-border);
-  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.25);
-  overflow: hidden;
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .dex-card::before {
-  content: "";
+  content: '';
   position: absolute;
-  inset: -40% 50% 40% -40%;
-  background: radial-gradient(circle at top, rgba(53, 243, 255, 0.25), transparent 70%);
+  inset: 0;
+  background: linear-gradient(135deg, rgba(200, 154, 59, 0.12), transparent 70%);
+  border-radius: inherit;
   opacity: 0;
   transition: opacity 0.3s ease;
   pointer-events: none;
+  z-index: 0;
 }
 
 .dex-card:hover,
 .dex-card:focus-within {
-  transform: translateY(-8px);
-  box-shadow: 0 26px 48px rgba(0, 0, 0, 0.35);
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-hover);
 }
 
 .dex-card:hover::before,
@@ -269,49 +282,59 @@ main {
   opacity: 1;
 }
 
+.dex-card__header,
+.dex-card__body {
+  position: relative;
+  z-index: 1;
+}
+
 .dex-card__header {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 8px 16px;
+  gap: 6px 16px;
   align-items: baseline;
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 }
 
 .dex-number {
-  font-family: 'Press Start 2P', monospace;
-  font-size: 0.7rem;
-  color: var(--accent-tertiary);
-  letter-spacing: 0.1rem;
+  font-family: 'Playfair Display', serif;
+  font-size: 0.9rem;
+  color: var(--accent-gold);
+  letter-spacing: 0.06rem;
 }
 
 .dex-card h2 {
   margin: 0;
-  font-size: 1.35rem;
-  color: var(--accent-primary);
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  color: var(--accent-fern);
 }
 
 .dex-role {
   grid-column: span 2;
-  font-size: 0.85rem;
-  color: rgba(255, 126, 219, 0.8);
+  font-size: 0.8rem;
+  letter-spacing: 0.12rem;
+  text-transform: uppercase;
+  color: var(--accent-clay);
 }
 
 .dex-card__body {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 16px;
 }
 
 .dex-portrait {
-  border-radius: 16px;
+  border-radius: 18px;
   overflow: hidden;
-  border: 1px solid rgba(255, 126, 219, 0.25);
-  box-shadow: inset 0 0 0 1px rgba(53, 243, 255, 0.2);
+  border: 1px solid rgba(181, 106, 45, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .dex-description {
   color: var(--text-muted);
-  line-height: 1.6;
+  font-size: 1rem;
+  line-height: 1.7;
 }
 
 .dex-stats {
@@ -320,29 +343,37 @@ main {
   padding: 0;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 10px 14px;
+  gap: 12px 14px;
 }
 
 .dex-stats li {
   display: flex;
   justify-content: space-between;
-  font-size: 0.85rem;
-  padding: 6px 10px;
-  background: rgba(3, 16, 26, 0.6);
-  border-radius: 10px;
-  border: 1px solid rgba(53, 243, 255, 0.15);
+  align-items: center;
+  font-size: 0.95rem;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 12px;
+  border: 1px solid rgba(84, 68, 41, 0.12);
+  color: var(--text-main);
+}
+
+.dex-stats li span:first-child {
+  font-weight: 600;
+  color: rgba(107, 90, 59, 0.85);
 }
 
 .dex-ability {
-  font-size: 0.95rem;
-  background: rgba(53, 243, 255, 0.08);
-  padding: 12px;
-  border-radius: 12px;
-  border: 1px solid rgba(53, 243, 255, 0.2);
+  font-size: 1rem;
+  background: rgba(79, 122, 85, 0.12);
+  border-left: 4px solid var(--accent-fern);
+  padding: 12px 14px;
+  border-radius: 14px;
+  color: var(--text-main);
 }
 
 .dex-ability strong {
-  color: var(--accent-secondary);
+  color: var(--accent-clay);
 }
 
 .dex-tags {
@@ -356,58 +387,59 @@ main {
 
 .dex-tags li {
   font-size: 0.75rem;
-  letter-spacing: 0.05rem;
+  letter-spacing: 0.08rem;
   text-transform: uppercase;
-  padding: 4px 10px;
+  padding: 6px 12px;
   border-radius: 999px;
-  background: rgba(3, 16, 26, 0.75);
-  border: 1px solid rgba(53, 243, 255, 0.25);
+  background: var(--badge-bg);
+  border: 1px solid rgba(79, 122, 85, 0.2);
+  color: var(--accent-fern);
 }
 
 .empty-state {
   text-align: center;
   font-size: 1rem;
-  color: rgba(200, 215, 255, 0.7);
+  color: rgba(107, 90, 59, 0.75);
   padding: 20px;
-  background: rgba(3, 16, 26, 0.65);
+  background: rgba(255, 250, 241, 0.85);
   border-radius: 16px;
-  border: 1px dashed rgba(53, 243, 255, 0.35);
+  border: 1px dashed rgba(181, 106, 45, 0.3);
 }
 
 .site-footer {
   text-align: center;
-  padding: 40px 24px 60px;
-  color: rgba(200, 215, 255, 0.6);
-  font-size: 0.85rem;
+  padding: 40px clamp(1.5rem, 4vw, 3rem) 60px;
+  color: rgba(107, 90, 59, 0.75);
+  font-size: 0.9rem;
 }
 
 .site-footer p {
   margin: 6px 0;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 960px) {
   .intro {
     grid-template-columns: 1fr;
   }
 
   .intro__metrics {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 720px) {
   .site-header__inner {
     flex-direction: column;
     align-items: flex-start;
   }
 
+  .site-nav {
+    width: 100%;
+  }
+
   .controls {
     flex-direction: column;
     align-items: stretch;
-  }
-
-  .control-group {
-    width: 100%;
   }
 
   .control-reset {

--- a/cambrian-pokedex.html
+++ b/cambrian-pokedex.html
@@ -94,13 +94,29 @@
       <div class="pokedex-grid">
         <article class="dex-card" data-name="Anomalocaris" data-diet="predator" data-habitat="pelagic" data-size="large">
           <div class="dex-card__header">
-            <span class="dex-number">#001</span>
-            <h2>Anomalocaris</h2>
-            <span class="dex-role">Apex Hunter</span>
+            <div class="dex-heading">
+              <div class="dex-heading-top">
+                <span class="dex-number">#001</span>
+                <span class="dex-role">Apex Hunter</span>
+              </div>
+              <h2>Anomalocaris</h2>
+            </div>
+            <div class="dex-avatar" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <rect width="64" height="64" rx="14" fill="#FDE5C9" />
+                <path d="M12 30c0-10 12-18 20-18s20 8 20 18-12 18-20 18S12 40 12 30Z" fill="#C46B3E" />
+                <path d="M20 30c0-6 6-11 12-11s12 5 12 11-6 11-12 11-12-5-12-11Z" fill="#F6D8B1" />
+                <path d="M19 38c4 6 10 10 13 10s9-4 13-10" stroke="#5E3B23" stroke-width="3" stroke-linecap="round" fill="none" />
+                <circle cx="23" cy="27" r="3" fill="#2F2A28" />
+                <circle cx="41" cy="27" r="3" fill="#2F2A28" />
+                <path d="M11 32c4 6 4 12 0 18" stroke="#C46B3E" stroke-width="3" stroke-linecap="round" fill="none" />
+                <path d="M53 32c-4 6-4 12 0 18" stroke="#C46B3E" stroke-width="3" stroke-linecap="round" fill="none" />
+              </svg>
+            </div>
           </div>
           <div class="dex-card__body">
             <figure class="dex-portrait">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/AnomalocarisBW.jpg/320px-AnomalocarisBW.jpg" alt="Reconstruction of Anomalocaris" loading="lazy" />
+              <img src="https://picsum.photos/seed/anomalocaris/200" alt="Illustrative portrait of Anomalocaris" loading="lazy" />
             </figure>
             <p class="dex-description">
               The undisputed titan of Cambrian seas. Twin graspers snared prey before a
@@ -123,13 +139,32 @@
 
         <article class="dex-card" data-name="Opabinia" data-diet="predator" data-habitat="benthic" data-size="small">
           <div class="dex-card__header">
-            <span class="dex-number">#002</span>
-            <h2>Opabinia</h2>
-            <span class="dex-role">Tactile Forager</span>
+            <div class="dex-heading">
+              <div class="dex-heading-top">
+                <span class="dex-number">#002</span>
+                <span class="dex-role">Tactile Forager</span>
+              </div>
+              <h2>Opabinia</h2>
+            </div>
+            <div class="dex-avatar" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <rect width="64" height="64" rx="14" fill="#E3F3EA" />
+                <ellipse cx="37" cy="36" rx="18" ry="12" fill="#5AA995" />
+                <ellipse cx="35" cy="33" rx="13" ry="9" fill="#A0DCC2" />
+                <path d="M23 34c-6-4-12-2-12 3s6 9 12 9" stroke="#2F725B" stroke-width="3" stroke-linecap="round" fill="none" />
+                <path d="M15 24c3-4 9-6 13-4" stroke="#2F725B" stroke-width="3" stroke-linecap="round" fill="none" />
+                <path d="M52 38c-4 4-10 6-16 6" stroke="#2F725B" stroke-width="3" stroke-linecap="round" fill="none" />
+                <circle cx="29" cy="25" r="2.2" fill="#1F3E34" />
+                <circle cx="33" cy="23" r="2.4" fill="#1F3E34" />
+                <circle cx="37" cy="22" r="2.2" fill="#1F3E34" />
+                <circle cx="41" cy="23" r="2.2" fill="#1F3E34" />
+                <circle cx="45" cy="25" r="2" fill="#1F3E34" />
+              </svg>
+            </div>
           </div>
           <div class="dex-card__body">
             <figure class="dex-portrait">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/OpabiniaRegalis-NT.jpg/320px-OpabiniaRegalis-NT.jpg" alt="Reconstruction of Opabinia" loading="lazy" />
+              <img src="https://picsum.photos/seed/opabinia/200" alt="Illustrative portrait of Opabinia" loading="lazy" />
             </figure>
             <p class="dex-description">
               Five independent eyes sweep the sea floor while a flexible proboscis vacuums
@@ -152,13 +187,32 @@
 
         <article class="dex-card" data-name="Hallucigenia" data-diet="detritivore" data-habitat="benthic" data-size="small">
           <div class="dex-card__header">
-            <span class="dex-number">#003</span>
-            <h2>Hallucigenia</h2>
-            <span class="dex-role">Spined Wanderer</span>
+            <div class="dex-heading">
+              <div class="dex-heading-top">
+                <span class="dex-number">#003</span>
+                <span class="dex-role">Spined Wanderer</span>
+              </div>
+              <h2>Hallucigenia</h2>
+            </div>
+            <div class="dex-avatar" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <rect width="64" height="64" rx="14" fill="#F6E6FA" />
+                <path d="M18 42c2-10 8-20 14-20s12 10 14 20H18Z" fill="#D39BD7" stroke="#854487" stroke-width="2" stroke-linejoin="round" />
+                <path d="M20 40c2-7 7-12 12-12s10 5 12 12H20Z" fill="#F2D7F3" />
+                <path d="M22 32L18 20" stroke="#854487" stroke-width="3" stroke-linecap="round" />
+                <path d="M28 30L26 18" stroke="#854487" stroke-width="3" stroke-linecap="round" />
+                <path d="M34 30L34 18" stroke="#854487" stroke-width="3" stroke-linecap="round" />
+                <path d="M40 32L44 20" stroke="#854487" stroke-width="3" stroke-linecap="round" />
+                <path d="M24 42l-3 8" stroke="#854487" stroke-width="3" stroke-linecap="round" />
+                <path d="M30 42l-2 8" stroke="#854487" stroke-width="3" stroke-linecap="round" />
+                <path d="M36 42l2 8" stroke="#854487" stroke-width="3" stroke-linecap="round" />
+                <path d="M42 42l3 8" stroke="#854487" stroke-width="3" stroke-linecap="round" />
+              </svg>
+            </div>
           </div>
           <div class="dex-card__body">
             <figure class="dex-portrait">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/HallucigeniaNT.jpg/320px-HallucigeniaNT.jpg" alt="Reconstruction of Hallucigenia" loading="lazy" />
+              <img src="https://picsum.photos/seed/hallucigenia/200" alt="Illustrative portrait of Hallucigenia" loading="lazy" />
             </figure>
             <p class="dex-description">
               A walking pincushion that tiptoes on soft claws while towering spines ward off
@@ -181,13 +235,31 @@
 
         <article class="dex-card" data-name="Wiwaxia" data-diet="grazer" data-habitat="benthic" data-size="medium">
           <div class="dex-card__header">
-            <span class="dex-number">#004</span>
-            <h2>Wiwaxia</h2>
-            <span class="dex-role">Armored Grazer</span>
+            <div class="dex-heading">
+              <div class="dex-heading-top">
+                <span class="dex-number">#004</span>
+                <span class="dex-role">Armored Grazer</span>
+              </div>
+              <h2>Wiwaxia</h2>
+            </div>
+            <div class="dex-avatar" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <rect width="64" height="64" rx="14" fill="#F4E9D8" />
+                <ellipse cx="32" cy="38" rx="18" ry="12" fill="#B68C4A" />
+                <ellipse cx="32" cy="35" rx="14" ry="9" fill="#E3C78B" />
+                <polygon points="16,30 10,18 22,24" fill="#8A6534" />
+                <polygon points="24,26 20,14 30,22" fill="#8A6534" />
+                <polygon points="40,26 34,14 44,22" fill="#8A6534" />
+                <polygon points="48,30 42,18 54,24" fill="#8A6534" />
+                <path d="M20 40l-6 6" stroke="#8A6534" stroke-width="3" stroke-linecap="round" />
+                <path d="M44 40l6 6" stroke="#8A6534" stroke-width="3" stroke-linecap="round" />
+                <path d="M24 46c4 2 8 2 12 0" stroke="#6B4A26" stroke-width="3" stroke-linecap="round" />
+              </svg>
+            </div>
           </div>
           <div class="dex-card__body">
             <figure class="dex-portrait">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Wiwaxia_NT_small.jpg/320px-Wiwaxia_NT_small.jpg" alt="Reconstruction of Wiwaxia" loading="lazy" />
+              <img src="https://picsum.photos/seed/wiwaxia/200" alt="Illustrative portrait of Wiwaxia" loading="lazy" />
             </figure>
             <p class="dex-description">
               Cloaked in overlapping scales and dagger-like spines, Wiwaxia scours microbial
@@ -210,13 +282,30 @@
 
         <article class="dex-card" data-name="Marrella" data-diet="filter-feeder" data-habitat="reef" data-size="small">
           <div class="dex-card__header">
-            <span class="dex-number">#005</span>
-            <h2>Marrella</h2>
-            <span class="dex-role">Lace Carapace</span>
+            <div class="dex-heading">
+              <div class="dex-heading-top">
+                <span class="dex-number">#005</span>
+                <span class="dex-role">Lace Carapace</span>
+              </div>
+              <h2>Marrella</h2>
+            </div>
+            <div class="dex-avatar" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <rect width="64" height="64" rx="14" fill="#E2F1F8" />
+                <path d="M18 44h28l-6-16H24l-6 16Z" fill="#3C6FA3" />
+                <path d="M22 36h20l4 8H18l4-8Z" fill="#6FA1C9" />
+                <path d="M24 28l-10-8" stroke="#3C6FA3" stroke-width="3" stroke-linecap="round" />
+                <path d="M40 28l10-8" stroke="#3C6FA3" stroke-width="3" stroke-linecap="round" />
+                <path d="M32 26c6 0 10-4 10-8" stroke="#3C6FA3" stroke-width="3" stroke-linecap="round" fill="none" />
+                <path d="M32 26c-6 0-10-4-10-8" stroke="#3C6FA3" stroke-width="3" stroke-linecap="round" fill="none" />
+                <circle cx="28" cy="32" r="2" fill="#172A3D" />
+                <circle cx="36" cy="32" r="2" fill="#172A3D" />
+              </svg>
+            </div>
           </div>
           <div class="dex-card__body">
             <figure class="dex-portrait">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Marrella_NT.jpg/320px-Marrella_NT.jpg" alt="Reconstruction of Marrella" loading="lazy" />
+              <img src="https://picsum.photos/seed/marrella/200" alt="Illustrative portrait of Marrella" loading="lazy" />
             </figure>
             <p class="dex-description">
               A delicately spined arthropod that skims plankton from reef currents using
@@ -239,13 +328,26 @@
 
         <article class="dex-card" data-name="Pikaia" data-diet="filter-feeder" data-habitat="open-shelf" data-size="small">
           <div class="dex-card__header">
-            <span class="dex-number">#006</span>
-            <h2>Pikaia</h2>
-            <span class="dex-role">Chordate Pioneer</span>
+            <div class="dex-heading">
+              <div class="dex-heading-top">
+                <span class="dex-number">#006</span>
+                <span class="dex-role">Chordate Pioneer</span>
+              </div>
+              <h2>Pikaia</h2>
+            </div>
+            <div class="dex-avatar" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <rect width="64" height="64" rx="14" fill="#E1F3F5" />
+                <path d="M12 40c4-14 12-22 20-22s16 8 20 22c-6 6-14 10-22 10S16 46 12 40Z" fill="#4D8F9C" />
+                <path d="M16 38c4-10 10-16 16-16s12 6 16 16c-4 4-10 8-16 8s-12-4-16-8Z" fill="#8CC3CB" />
+                <path d="M18 40c6 2 18 2 28-4" stroke="#2E5960" stroke-width="3" stroke-linecap="round" fill="none" />
+                <circle cx="22" cy="28" r="2" fill="#1A3C42" />
+              </svg>
+            </div>
           </div>
           <div class="dex-card__body">
             <figure class="dex-portrait">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5b/PikaiaNT.jpg/320px-PikaiaNT.jpg" alt="Reconstruction of Pikaia" loading="lazy" />
+              <img src="https://picsum.photos/seed/pikaia/200" alt="Illustrative portrait of Pikaia" loading="lazy" />
             </figure>
             <p class="dex-description">
               One of the first chordates, sporting a notochord and muscle blocks that ripple
@@ -268,13 +370,31 @@
 
         <article class="dex-card" data-name="Olenoides" data-diet="detritivore" data-habitat="benthic" data-size="medium">
           <div class="dex-card__header">
-            <span class="dex-number">#007</span>
-            <h2>Olenoides</h2>
-            <span class="dex-role">Trilobite Vanguard</span>
+            <div class="dex-heading">
+              <div class="dex-heading-top">
+                <span class="dex-number">#007</span>
+                <span class="dex-role">Trilobite Vanguard</span>
+              </div>
+              <h2>Olenoides</h2>
+            </div>
+            <div class="dex-avatar" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <rect width="64" height="64" rx="14" fill="#F3EBDE" />
+                <path d="M24 18c0-4 8-8 8-8s8 4 8 8v28c0 8-6 12-8 12s-8-4-8-12V18Z" fill="#9B6136" />
+                <path d="M24 22h16" stroke="#C88B54" stroke-width="3" stroke-linecap="round" />
+                <path d="M24 28h16" stroke="#C88B54" stroke-width="3" stroke-linecap="round" />
+                <path d="M24 34h16" stroke="#C88B54" stroke-width="3" stroke-linecap="round" />
+                <path d="M24 40h16" stroke="#C88B54" stroke-width="3" stroke-linecap="round" />
+                <path d="M20 44l-6 6" stroke="#9B6136" stroke-width="3" stroke-linecap="round" />
+                <path d="M44 44l6 6" stroke="#9B6136" stroke-width="3" stroke-linecap="round" />
+                <circle cx="26" cy="24" r="2" fill="#402312" />
+                <circle cx="38" cy="24" r="2" fill="#402312" />
+              </svg>
+            </div>
           </div>
           <div class="dex-card__body">
             <figure class="dex-portrait">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Olenoides_sp.jpg/320px-Olenoides_sp.jpg" alt="Fossil of Olenoides trilobite" loading="lazy" />
+              <img src="https://picsum.photos/seed/olenoides/200" alt="Illustrative portrait of Olenoides" loading="lazy" />
             </figure>
             <p class="dex-description">
               A versatile trilobite that patrols sediment for carrion and scraps, rolling
@@ -297,13 +417,31 @@
 
         <article class="dex-card" data-name="Waptia" data-diet="omnivore" data-habitat="pelagic" data-size="small">
           <div class="dex-card__header">
-            <span class="dex-number">#008</span>
-            <h2>Waptia</h2>
-            <span class="dex-role">Shrimp Sprinter</span>
+            <div class="dex-heading">
+              <div class="dex-heading-top">
+                <span class="dex-number">#008</span>
+                <span class="dex-role">Shrimp Sprinter</span>
+              </div>
+              <h2>Waptia</h2>
+            </div>
+            <div class="dex-avatar" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <rect width="64" height="64" rx="14" fill="#E6F5EC" />
+                <path d="M18 38c4-12 16-18 28-14s10 14 2 20-22 8-30-6Z" fill="#5FA785" />
+                <path d="M22 36c4-8 14-12 22-10s10 10 2 14-18 6-24-4Z" fill="#9BD6B8" />
+                <path d="M18 30C12 22 12 16 16 12" stroke="#2F6A4C" stroke-width="3" stroke-linecap="round" fill="none" />
+                <path d="M22 40l-6 8" stroke="#2F6A4C" stroke-width="3" stroke-linecap="round" />
+                <path d="M28 42l-4 8" stroke="#2F6A4C" stroke-width="3" stroke-linecap="round" />
+                <path d="M34 42l-2 8" stroke="#2F6A4C" stroke-width="3" stroke-linecap="round" />
+                <path d="M40 40l2 8" stroke="#2F6A4C" stroke-width="3" stroke-linecap="round" />
+                <path d="M46 38l6 6-10 2" stroke="#2F6A4C" stroke-width="3" stroke-linecap="round" fill="none" />
+                <circle cx="24" cy="30" r="2" fill="#1C3A2B" />
+              </svg>
+            </div>
           </div>
           <div class="dex-card__body">
             <figure class="dex-portrait">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/06/Waptia_fieldensis.jpg/320px-Waptia_fieldensis.jpg" alt="Fossil of Waptia" loading="lazy" />
+              <img src="https://picsum.photos/seed/waptia/200" alt="Illustrative portrait of Waptia" loading="lazy" />
             </figure>
             <p class="dex-description">
               A nimble swimmer with fan-like appendages for quick propulsion and delicate
@@ -326,13 +464,29 @@
 
         <article class="dex-card" data-name="Nectocaris" data-diet="predator" data-habitat="pelagic" data-size="medium">
           <div class="dex-card__header">
-            <span class="dex-number">#009</span>
-            <h2>Nectocaris</h2>
-            <span class="dex-role">Cephalopod Cousin</span>
+            <div class="dex-heading">
+              <div class="dex-heading-top">
+                <span class="dex-number">#009</span>
+                <span class="dex-role">Cephalopod Cousin</span>
+              </div>
+              <h2>Nectocaris</h2>
+            </div>
+            <div class="dex-avatar" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <rect width="64" height="64" rx="14" fill="#E4ECF8" />
+                <path d="M24 16c0-4 8-8 8-8s8 4 8 8v18c0 6-3 12-8 16-5-4-8-10-8-16V16Z" fill="#5B7CB8" />
+                <path d="M20 30c4-6 12-10 12-10s8 4 12 10" stroke="#2F4A82" stroke-width="3" stroke-linecap="round" fill="none" />
+                <path d="M20 32c-4 6-4 12 0 16" stroke="#2F4A82" stroke-width="3" stroke-linecap="round" fill="none" />
+                <path d="M44 32c4 6 4 12 0 16" stroke="#2F4A82" stroke-width="3" stroke-linecap="round" fill="none" />
+                <path d="M28 48c0 4 2 8 4 8s4-4 4-8" stroke="#2F4A82" stroke-width="3" stroke-linecap="round" fill="none" />
+                <circle cx="28" cy="24" r="2" fill="#16233D" />
+                <circle cx="36" cy="24" r="2" fill="#16233D" />
+              </svg>
+            </div>
           </div>
           <div class="dex-card__body">
             <figure class="dex-portrait">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/95/NectocarisNT.jpg/320px-NectocarisNT.jpg" alt="Reconstruction of Nectocaris" loading="lazy" />
+              <img src="https://picsum.photos/seed/nectocaris/200" alt="Illustrative portrait of Nectocaris" loading="lazy" />
             </figure>
             <p class="dex-description">
               A soft-bodied hunter with lateral fins and a siphon that hint at future
@@ -355,13 +509,28 @@
 
         <article class="dex-card" data-name="Dinomischus" data-diet="filter-feeder" data-habitat="slope" data-size="medium">
           <div class="dex-card__header">
-            <span class="dex-number">#010</span>
-            <h2>Dinomischus</h2>
-            <span class="dex-role">Anchored Cup</span>
+            <div class="dex-heading">
+              <div class="dex-heading-top">
+                <span class="dex-number">#010</span>
+                <span class="dex-role">Anchored Cup</span>
+              </div>
+              <h2>Dinomischus</h2>
+            </div>
+            <div class="dex-avatar" aria-hidden="true">
+              <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+                <rect width="64" height="64" rx="14" fill="#F1F0E7" />
+                <ellipse cx="32" cy="24" rx="14" ry="10" fill="#D1B16D" />
+                <ellipse cx="32" cy="22" rx="12" ry="8" fill="#F5DFA8" />
+                <rect x="26" y="26" width="12" height="18" rx="6" fill="#B8914F" />
+                <path d="M18 24c6-6 22-6 28 0" stroke="#9B7B3E" stroke-width="3" stroke-linecap="round" fill="none" />
+                <rect x="30" y="44" width="4" height="12" fill="#6A5128" />
+                <path d="M24 56c2 4 12 4 16 0" stroke="#6A5128" stroke-width="3" stroke-linecap="round" fill="none" />
+              </svg>
+            </div>
           </div>
           <div class="dex-card__body">
             <figure class="dex-portrait">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/Dinomischus_isolated.jpg/320px-Dinomischus_isolated.jpg" alt="Reconstruction of Dinomischus" loading="lazy" />
+              <img src="https://picsum.photos/seed/dinomischus/200" alt="Illustrative portrait of Dinomischus" loading="lazy" />
             </figure>
             <p class="dex-description">
               A stationary stalked animal rooted into continental slopes. Its petal-like
@@ -388,7 +557,7 @@
 
   <footer class="site-footer">
     <p>Sources include the Burgess Shale and Chengjiang fossil beds research archives.</p>
-    <p>Illustrations courtesy of Wikimedia Commons contributors.</p>
+    <p>Portrait placeholders via Picsum Photos; mini avatars illustrated especially for this guide.</p>
   </footer>
 
   <script src="cambrian-pokedex.js"></script>

--- a/cambrian-pokedex.html
+++ b/cambrian-pokedex.html
@@ -4,22 +4,22 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Cambrian Lifeform Dex</title>
+  <title>Cambrian Safari Field Guide</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Work+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600;700&family=Source+Sans+3:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="cambrian-pokedex.css" />
 </head>
 <body>
   <header class="site-header">
     <div class="site-header__inner">
       <div class="logo-cluster">
-        <span class="dex-label">EraDex</span>
-        <h1 class="site-title">Cambrian Explosion Field Guide</h1>
+        <span class="dex-label">Field Journal</span>
+        <h1 class="site-title">Cambrian Safari Field Guide</h1>
       </div>
       <nav class="site-nav">
         <a href="index.html">Back to Portfolio</a>
-        <a class="nav-highlight" href="#dex">Browse Entries</a>
+        <a class="nav-highlight" href="#dex">Creature Log</a>
         <a href="#about">About the Era</a>
       </nav>
     </div>
@@ -28,33 +28,33 @@
   <main>
     <section class="intro" id="about">
       <div class="intro__content">
-        <h2>Welcome, Field Researcher!</h2>
+        <h2>Welcome, Expedition Leader!</h2>
         <p>
-          This pocket database captures the dazzling diversity of the Cambrian explosion
-          (≈541&ndash;485 million years ago). Use the controls to search, filter, and compare
-          the earliest complex animals that cruised ancient seas.
+          Pack your field lenses and wade into Cambrian seas alive with experimental wildlife.
+          This safari log charts the explosion of early animal life (≈541&ndash;485 million years ago).
+          Use the filters to scout predators, grazers, and marvels from every habitat zone.
         </p>
       </div>
       <div class="intro__metrics">
         <div class="metric">
-          <span class="metric__label">Documented taxa</span>
+          <span class="metric__label">Species logged</span>
           <span class="metric__value">10</span>
         </div>
         <div class="metric">
-          <span class="metric__label">Habitats logged</span>
+          <span class="metric__label">Habitats scouted</span>
           <span class="metric__value">5</span>
         </div>
         <div class="metric">
-          <span class="metric__label">Top predators</span>
+          <span class="metric__label">Apex hunters</span>
           <span class="metric__value">3</span>
         </div>
       </div>
     </section>
 
-    <section class="controls" aria-label="Dex filters">
+    <section class="controls" aria-label="Safari filters">
       <div class="control-group">
         <label for="dex-search">Search</label>
-        <input type="search" id="dex-search" placeholder="Name, ability, or trait" />
+        <input type="search" id="dex-search" placeholder="Name, adaptation, or trait" />
       </div>
       <div class="control-group">
         <label for="diet-filter">Feeding style</label>
@@ -87,7 +87,7 @@
           <option value="small">Small (&lt;10 cm)</option>
         </select>
       </div>
-      <button class="control-reset" type="button" id="reset-filters">Reset Filters</button>
+      <button class="control-reset" type="button" id="reset-filters">Reset filters</button>
     </section>
 
     <section class="pokedex" id="dex" aria-live="polite">
@@ -382,7 +382,7 @@
           </div>
         </article>
       </div>
-      <p class="empty-state" hidden>No Cambrian creatures match those filters. Adjust the search to rediscover them.</p>
+      <p class="empty-state" hidden>No sightings match those filters. Adjust the search to rediscover them.</p>
     </section>
   </main>
 

--- a/cambrian-pokedex.html
+++ b/cambrian-pokedex.html
@@ -1,0 +1,396 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cambrian Lifeform Dex</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Work+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="cambrian-pokedex.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <div class="logo-cluster">
+        <span class="dex-label">EraDex</span>
+        <h1 class="site-title">Cambrian Explosion Field Guide</h1>
+      </div>
+      <nav class="site-nav">
+        <a href="index.html">Back to Portfolio</a>
+        <a class="nav-highlight" href="#dex">Browse Entries</a>
+        <a href="#about">About the Era</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="intro" id="about">
+      <div class="intro__content">
+        <h2>Welcome, Field Researcher!</h2>
+        <p>
+          This pocket database captures the dazzling diversity of the Cambrian explosion
+          (≈541&ndash;485 million years ago). Use the controls to search, filter, and compare
+          the earliest complex animals that cruised ancient seas.
+        </p>
+      </div>
+      <div class="intro__metrics">
+        <div class="metric">
+          <span class="metric__label">Documented taxa</span>
+          <span class="metric__value">10</span>
+        </div>
+        <div class="metric">
+          <span class="metric__label">Habitats logged</span>
+          <span class="metric__value">5</span>
+        </div>
+        <div class="metric">
+          <span class="metric__label">Top predators</span>
+          <span class="metric__value">3</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="controls" aria-label="Dex filters">
+      <div class="control-group">
+        <label for="dex-search">Search</label>
+        <input type="search" id="dex-search" placeholder="Name, ability, or trait" />
+      </div>
+      <div class="control-group">
+        <label for="diet-filter">Feeding style</label>
+        <select id="diet-filter">
+          <option value="all">All</option>
+          <option value="predator">Predator</option>
+          <option value="grazer">Grazer</option>
+          <option value="detritivore">Detritivore</option>
+          <option value="filter-feeder">Filter feeder</option>
+          <option value="omnivore">Omnivore</option>
+        </select>
+      </div>
+      <div class="control-group">
+        <label for="habitat-filter">Habitat zone</label>
+        <select id="habitat-filter">
+          <option value="all">All</option>
+          <option value="pelagic">Pelagic</option>
+          <option value="benthic">Benthic</option>
+          <option value="reef">Reef</option>
+          <option value="slope">Continental slope</option>
+          <option value="open-shelf">Open shelf</option>
+        </select>
+      </div>
+      <div class="control-group">
+        <label for="size-filter">Body size</label>
+        <select id="size-filter">
+          <option value="all">All</option>
+          <option value="large">Large (&gt;50 cm)</option>
+          <option value="medium">Medium (10&ndash;50 cm)</option>
+          <option value="small">Small (&lt;10 cm)</option>
+        </select>
+      </div>
+      <button class="control-reset" type="button" id="reset-filters">Reset Filters</button>
+    </section>
+
+    <section class="pokedex" id="dex" aria-live="polite">
+      <div class="pokedex-grid">
+        <article class="dex-card" data-name="Anomalocaris" data-diet="predator" data-habitat="pelagic" data-size="large">
+          <div class="dex-card__header">
+            <span class="dex-number">#001</span>
+            <h2>Anomalocaris</h2>
+            <span class="dex-role">Apex Hunter</span>
+          </div>
+          <div class="dex-card__body">
+            <figure class="dex-portrait">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/AnomalocarisBW.jpg/320px-AnomalocarisBW.jpg" alt="Reconstruction of Anomalocaris" loading="lazy" />
+            </figure>
+            <p class="dex-description">
+              The undisputed titan of Cambrian seas. Twin graspers snared prey before a
+              circular mouth shredded trilobites with pineapple-slice teeth.
+            </p>
+            <ul class="dex-stats">
+              <li><span>Length</span><span>Up to 1 m</span></li>
+              <li><span>Armor breach</span><span>High</span></li>
+              <li><span>Visual acuity</span><span>12k facets</span></li>
+              <li><span>Swim burst</span><span>22 km/h</span></li>
+            </ul>
+            <p class="dex-ability"><strong>Signature ability:</strong> Raptorial Sweep &mdash; lunges with barbed arms to immobilize prey.</p>
+            <ul class="dex-tags">
+              <li>Pelagic</li>
+              <li>Predator</li>
+              <li>Large</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="dex-card" data-name="Opabinia" data-diet="predator" data-habitat="benthic" data-size="small">
+          <div class="dex-card__header">
+            <span class="dex-number">#002</span>
+            <h2>Opabinia</h2>
+            <span class="dex-role">Tactile Forager</span>
+          </div>
+          <div class="dex-card__body">
+            <figure class="dex-portrait">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/OpabiniaRegalis-NT.jpg/320px-OpabiniaRegalis-NT.jpg" alt="Reconstruction of Opabinia" loading="lazy" />
+            </figure>
+            <p class="dex-description">
+              Five independent eyes sweep the sea floor while a flexible proboscis vacuums
+              soft-bodied prey from burrows and crevices.
+            </p>
+            <ul class="dex-stats">
+              <li><span>Length</span><span>7 cm</span></li>
+              <li><span>Agility</span><span>Medium</span></li>
+              <li><span>Eye count</span><span>5</span></li>
+              <li><span>Grasper reach</span><span>15 cm</span></li>
+            </ul>
+            <p class="dex-ability"><strong>Signature ability:</strong> Periscope Grab &mdash; extends its trunk to snatch hidden morsels.</p>
+            <ul class="dex-tags">
+              <li>Benthic</li>
+              <li>Predator</li>
+              <li>Small</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="dex-card" data-name="Hallucigenia" data-diet="detritivore" data-habitat="benthic" data-size="small">
+          <div class="dex-card__header">
+            <span class="dex-number">#003</span>
+            <h2>Hallucigenia</h2>
+            <span class="dex-role">Spined Wanderer</span>
+          </div>
+          <div class="dex-card__body">
+            <figure class="dex-portrait">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/HallucigeniaNT.jpg/320px-HallucigeniaNT.jpg" alt="Reconstruction of Hallucigenia" loading="lazy" />
+            </figure>
+            <p class="dex-description">
+              A walking pincushion that tiptoes on soft claws while towering spines ward off
+              would-be attackers seeking an easy snack.
+            </p>
+            <ul class="dex-stats">
+              <li><span>Length</span><span>3.5 cm</span></li>
+              <li><span>Defense</span><span>Extreme</span></li>
+              <li><span>Speed</span><span>Slow</span></li>
+              <li><span>Stability</span><span>Eight limbs</span></li>
+            </ul>
+            <p class="dex-ability"><strong>Signature ability:</strong> Needle Shield &mdash; lashes outward spines to deter predators.</p>
+            <ul class="dex-tags">
+              <li>Benthic</li>
+              <li>Detritivore</li>
+              <li>Small</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="dex-card" data-name="Wiwaxia" data-diet="grazer" data-habitat="benthic" data-size="medium">
+          <div class="dex-card__header">
+            <span class="dex-number">#004</span>
+            <h2>Wiwaxia</h2>
+            <span class="dex-role">Armored Grazer</span>
+          </div>
+          <div class="dex-card__body">
+            <figure class="dex-portrait">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Wiwaxia_NT_small.jpg/320px-Wiwaxia_NT_small.jpg" alt="Reconstruction of Wiwaxia" loading="lazy" />
+            </figure>
+            <p class="dex-description">
+              Cloaked in overlapping scales and dagger-like spines, Wiwaxia scours microbial
+              mats with twin radulae while shrugging off attacks.
+            </p>
+            <ul class="dex-stats">
+              <li><span>Length</span><span>5 cm</span></li>
+              <li><span>Armor</span><span>Heavy plates</span></li>
+              <li><span>Feeding rate</span><span>High</span></li>
+              <li><span>Threat response</span><span>Spine flare</span></li>
+            </ul>
+            <p class="dex-ability"><strong>Signature ability:</strong> Scale Barricade &mdash; curls into a bristling orb of spines.</p>
+            <ul class="dex-tags">
+              <li>Benthic</li>
+              <li>Grazer</li>
+              <li>Medium</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="dex-card" data-name="Marrella" data-diet="filter-feeder" data-habitat="reef" data-size="small">
+          <div class="dex-card__header">
+            <span class="dex-number">#005</span>
+            <h2>Marrella</h2>
+            <span class="dex-role">Lace Carapace</span>
+          </div>
+          <div class="dex-card__body">
+            <figure class="dex-portrait">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Marrella_NT.jpg/320px-Marrella_NT.jpg" alt="Reconstruction of Marrella" loading="lazy" />
+            </figure>
+            <p class="dex-description">
+              A delicately spined arthropod that skims plankton from reef currents using
+              feathery limbs and antennae.
+            </p>
+            <ul class="dex-stats">
+              <li><span>Length</span><span>2.5 cm</span></li>
+              <li><span>Swarm behavior</span><span>High</span></li>
+              <li><span>Vision</span><span>Wide angle</span></li>
+              <li><span>Molting cycle</span><span>Frequent</span></li>
+            </ul>
+            <p class="dex-ability"><strong>Signature ability:</strong> Reef Drift &mdash; rides surge pulses to avoid predators.</p>
+            <ul class="dex-tags">
+              <li>Reef</li>
+              <li>Filter feeder</li>
+              <li>Small</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="dex-card" data-name="Pikaia" data-diet="filter-feeder" data-habitat="open-shelf" data-size="small">
+          <div class="dex-card__header">
+            <span class="dex-number">#006</span>
+            <h2>Pikaia</h2>
+            <span class="dex-role">Chordate Pioneer</span>
+          </div>
+          <div class="dex-card__body">
+            <figure class="dex-portrait">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5b/PikaiaNT.jpg/320px-PikaiaNT.jpg" alt="Reconstruction of Pikaia" loading="lazy" />
+            </figure>
+            <p class="dex-description">
+              One of the first chordates, sporting a notochord and muscle blocks that ripple
+              in coordinated waves for agile swimming.
+            </p>
+            <ul class="dex-stats">
+              <li><span>Length</span><span>5 cm</span></li>
+              <li><span>Locomotion</span><span>Lateral undulation</span></li>
+              <li><span>Respiration</span><span>Body surface</span></li>
+              <li><span>Resilience</span><span>Moderate</span></li>
+            </ul>
+            <p class="dex-ability"><strong>Signature ability:</strong> Notochord Dash &mdash; bursts forward with wave-like contractions.</p>
+            <ul class="dex-tags">
+              <li>Open shelf</li>
+              <li>Filter feeder</li>
+              <li>Small</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="dex-card" data-name="Olenoides" data-diet="detritivore" data-habitat="benthic" data-size="medium">
+          <div class="dex-card__header">
+            <span class="dex-number">#007</span>
+            <h2>Olenoides</h2>
+            <span class="dex-role">Trilobite Vanguard</span>
+          </div>
+          <div class="dex-card__body">
+            <figure class="dex-portrait">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Olenoides_sp.jpg/320px-Olenoides_sp.jpg" alt="Fossil of Olenoides trilobite" loading="lazy" />
+            </figure>
+            <p class="dex-description">
+              A versatile trilobite that patrols sediment for carrion and scraps, rolling
+              into an armored pill when danger looms.
+            </p>
+            <ul class="dex-stats">
+              <li><span>Length</span><span>8&ndash;12 cm</span></li>
+              <li><span>Enrollment</span><span>Complete</span></li>
+              <li><span>Antennae</span><span>Highly sensitive</span></li>
+              <li><span>Spines</span><span>Posterior fan</span></li>
+            </ul>
+            <p class="dex-ability"><strong>Signature ability:</strong> Triloshield &mdash; locks into a tight defensive ball.</p>
+            <ul class="dex-tags">
+              <li>Benthic</li>
+              <li>Detritivore</li>
+              <li>Medium</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="dex-card" data-name="Waptia" data-diet="omnivore" data-habitat="pelagic" data-size="small">
+          <div class="dex-card__header">
+            <span class="dex-number">#008</span>
+            <h2>Waptia</h2>
+            <span class="dex-role">Shrimp Sprinter</span>
+          </div>
+          <div class="dex-card__body">
+            <figure class="dex-portrait">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/06/Waptia_fieldensis.jpg/320px-Waptia_fieldensis.jpg" alt="Fossil of Waptia" loading="lazy" />
+            </figure>
+            <p class="dex-description">
+              A nimble swimmer with fan-like appendages for quick propulsion and delicate
+              limbs for scooping plankton or scavenging.
+            </p>
+            <ul class="dex-stats">
+              <li><span>Length</span><span>4 cm</span></li>
+              <li><span>Brood care</span><span>Egg cluster</span></li>
+              <li><span>Speed</span><span>Fast bursts</span></li>
+              <li><span>Exoskeleton</span><span>Lightweight</span></li>
+            </ul>
+            <p class="dex-ability"><strong>Signature ability:</strong> Jet Flick &mdash; tail-flick launches it away from threats.</p>
+            <ul class="dex-tags">
+              <li>Pelagic</li>
+              <li>Omnivore</li>
+              <li>Small</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="dex-card" data-name="Nectocaris" data-diet="predator" data-habitat="pelagic" data-size="medium">
+          <div class="dex-card__header">
+            <span class="dex-number">#009</span>
+            <h2>Nectocaris</h2>
+            <span class="dex-role">Cephalopod Cousin</span>
+          </div>
+          <div class="dex-card__body">
+            <figure class="dex-portrait">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/95/NectocarisNT.jpg/320px-NectocarisNT.jpg" alt="Reconstruction of Nectocaris" loading="lazy" />
+            </figure>
+            <p class="dex-description">
+              A soft-bodied hunter with lateral fins and a siphon that hint at future
+              cephalopods. Twin tentacles snap up prey in open water.
+            </p>
+            <ul class="dex-stats">
+              <li><span>Length</span><span>10 cm</span></li>
+              <li><span>Propulsion</span><span>Jet siphon</span></li>
+              <li><span>Fins</span><span>Stabilizing</span></li>
+              <li><span>Prey capture</span><span>Grasping tentacles</span></li>
+            </ul>
+            <p class="dex-ability"><strong>Signature ability:</strong> Phantom Surge &mdash; pulsed jets let it pivot instantly.</p>
+            <ul class="dex-tags">
+              <li>Pelagic</li>
+              <li>Predator</li>
+              <li>Medium</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="dex-card" data-name="Dinomischus" data-diet="filter-feeder" data-habitat="slope" data-size="medium">
+          <div class="dex-card__header">
+            <span class="dex-number">#010</span>
+            <h2>Dinomischus</h2>
+            <span class="dex-role">Anchored Cup</span>
+          </div>
+          <div class="dex-card__body">
+            <figure class="dex-portrait">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/Dinomischus_isolated.jpg/320px-Dinomischus_isolated.jpg" alt="Reconstruction of Dinomischus" loading="lazy" />
+            </figure>
+            <p class="dex-description">
+              A stationary stalked animal rooted into continental slopes. Its petal-like
+              feeding basket whirls plankton toward the mouth.
+            </p>
+            <ul class="dex-stats">
+              <li><span>Height</span><span>10 cm</span></li>
+              <li><span>Feeding fan</span><span>360° sweep</span></li>
+              <li><span>Colony density</span><span>Clustered</span></li>
+              <li><span>Anchoring</span><span>Flexible stem</span></li>
+            </ul>
+            <p class="dex-ability"><strong>Signature ability:</strong> Vortex Bloom &mdash; spins feeding petals to create a suction current.</p>
+            <ul class="dex-tags">
+              <li>Continental slope</li>
+              <li>Filter feeder</li>
+              <li>Medium</li>
+            </ul>
+          </div>
+        </article>
+      </div>
+      <p class="empty-state" hidden>No Cambrian creatures match those filters. Adjust the search to rediscover them.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>Sources include the Burgess Shale and Chengjiang fossil beds research archives.</p>
+    <p>Illustrations courtesy of Wikimedia Commons contributors.</p>
+  </footer>
+
+  <script src="cambrian-pokedex.js"></script>
+</body>
+</html>

--- a/cambrian-pokedex.js
+++ b/cambrian-pokedex.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const searchInput = document.getElementById('dex-search');
+  const dietFilter = document.getElementById('diet-filter');
+  const habitatFilter = document.getElementById('habitat-filter');
+  const sizeFilter = document.getElementById('size-filter');
+  const resetButton = document.getElementById('reset-filters');
+  const cards = Array.from(document.querySelectorAll('.dex-card'));
+  const emptyState = document.querySelector('.empty-state');
+
+  const filterCards = () => {
+    const searchTerm = searchInput.value.trim().toLowerCase();
+    const dietValue = dietFilter.value;
+    const habitatValue = habitatFilter.value;
+    const sizeValue = sizeFilter.value;
+
+    let visibleCount = 0;
+
+    cards.forEach((card) => {
+      const matchesDiet = dietValue === 'all' || card.dataset.diet === dietValue;
+      const matchesHabitat = habitatValue === 'all' || card.dataset.habitat === habitatValue;
+      const matchesSize = sizeValue === 'all' || card.dataset.size === sizeValue;
+
+      const textBlob = [
+        card.dataset.name,
+        card.querySelector('.dex-description')?.textContent || '',
+        card.querySelector('.dex-ability')?.textContent || '',
+        Array.from(card.querySelectorAll('.dex-tags li'))
+          .map((tag) => tag.textContent)
+          .join(' '),
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      const matchesSearch = searchTerm.length === 0 || textBlob.includes(searchTerm);
+      const isVisible = matchesDiet && matchesHabitat && matchesSize && matchesSearch;
+
+      card.hidden = !isVisible;
+      card.setAttribute('aria-hidden', String(!isVisible));
+
+      if (isVisible) {
+        visibleCount += 1;
+      }
+    });
+
+    emptyState.hidden = visibleCount !== 0;
+  };
+
+  searchInput.addEventListener('input', filterCards);
+  dietFilter.addEventListener('change', filterCards);
+  habitatFilter.addEventListener('change', filterCards);
+  sizeFilter.addEventListener('change', filterCards);
+
+  resetButton.addEventListener('click', () => {
+    searchInput.value = '';
+    dietFilter.value = 'all';
+    habitatFilter.value = 'all';
+    sizeFilter.value = 'all';
+    filterCards();
+    searchInput.focus();
+  });
+
+  filterCards();
+});

--- a/index.html
+++ b/index.html
@@ -15,9 +15,10 @@
 	</style>
 </head>
 <body>
-	<h1>My Projects</h1>
-	<ul>
-		<li><a href="hcmc-job-board.html">Ho Chi Minh City Dev Job Board — noisy Chinese-style UI</a></li>
-	</ul>
+        <h1>My Projects</h1>
+        <ul>
+                <li><a href="cambrian-pokedex.html">Cambrian Explosion Lifeform Dex — interactive paleo Pokédex</a></li>
+                <li><a href="hcmc-job-board.html">Ho Chi Minh City Dev Job Board — noisy Chinese-style UI</a></li>
+        </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a Cambrian Explosion "EraDex" page with searchable, filterable entries for 10 notable lifeforms
- craft a neon-inspired Pokedex layout with responsive cards, controls, and stats styling
- hook up client-side filtering logic and link the new page from the portfolio home

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c88394a45483298c15fbc8cbf3ef2a